### PR TITLE
Add Python3 compatibility without breaking Python2.7 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,12 @@ git clone https://github.com/RikVN/DRS_parsing
 
 ### Prerequisites
 
-All script are written in Python 2.7. Make sure to install [psutil](https://pypi.python.org/pypi/psutil) and [yaml](https://pypi.org/project/PyYAML/).
+All script are written in Python 2.7 (but should work with Python 3.5+).
+Install requirements using:
+
+```
+pip install -r requirements.txt
+```
 
 ## Counter: evaluating scoped meaning representations
 

--- a/evaluation/clf_referee.py
+++ b/evaluation/clf_referee.py
@@ -23,19 +23,19 @@ def check_clf(clf, signature, v=0):
     '''checks well-formedness of a clausal form'''
     # get argument typing and for each clause an operator type 
     (op_types, arg_typing) = clf_typing(clf, signature, v=v)
-    if v>=3: print "Typing: {}".format(pr_2rel(arg_typing.items(), sep=':'))
+    if v>=3: print("Typing: {}".format(pr_2rel(arg_typing.items(), sep=':')))
     # get dictionary of box objects
     box_dict = clf_to_box_dict(clf, op_types, arg_typing, v=v)
-    if v>=2: print "#boxes = {}".format(len(box_dict))
+    if v>=2: print("#boxes = {}".format(len(box_dict)))
     if v>=3: 
         for b in box_dict:
             pr_box(box_dict[b])   
     # get transitive closure of subordinate relation (as set)
     sub_rel = box_dict_to_subordinate_rel(box_dict, v=v)
-    if v>=2: print "Subordinate relation: {}".format(pr_2rel(sub_rel))
+    if v>=2: print("Subordinate relation: {}".format(pr_2rel(sub_rel)))
     # get main box name
     main_box = detect_main_box(box_dict, sub_rel, v=v)
-    if v>=2: print "Main box is {}".format(main_box)
+    if v>=2: print("Main box is {}".format(main_box))
     # find is there are unbound referents
     unbound_refs = unbound_referents(box_dict, sub_rel, v=v)
     if unbound_refs:
@@ -62,7 +62,7 @@ def clf_typing(clf, signature, v=0):
     for cl in clf:
         (op_type, typing) = clause_typing(cl, signature, v=v)
         op_types.append(op_type)
-        if v >= 4: print "{}: {} @ {}".format(pr_clause(cl), op_type, pr_2rel(typing, sep=':'))  
+        if v >= 4: print("{}: {} @ {}".format(pr_clause(cl), op_type, pr_2rel(typing, sep=':')))
         for (arg, t) in typing:
             # make type more specific if possible
             t = specify_arg_type(arg, t, v=v) # 't' might become 'c' or 'x'   
@@ -76,9 +76,9 @@ def clf_typing(clf, signature, v=0):
                 arg_typing[arg] = t
     #print arg_typing info
     #for (i, cl) in enumerate(clf):
-    #    print "{}: {} @ {}".format(cl, op_types[i][0], op_types[i][1])
+    #    print("{}: {} @ {}".format(cl, op_types[i][0], op_types[i][1]))
     #for var in arg_typing:
-    #    print "{} of type {}".format(var, arg_typing[var])      
+    #    print("{} of type {}".format(var, arg_typing[var]))
     return (op_types, arg_typing)        
     
 #################################
@@ -101,7 +101,7 @@ def specify_arg_type(arg, t, v=0):
        and return a type, more specific if possible 
        (e.g., "now" will be of type c instead of t)
     '''
-    if v >= 5: print arg, t
+    if v >= 5: print(arg, t)
     # argument is in double quotes or has no quotes 
     if (not re.match('"[^"]+"$', arg) and 
         not re.match('[^"]+$', arg)): # try without re
@@ -199,7 +199,7 @@ def file_to_clfs(filepath, v=0):
                 continue
             # remove % comments if any
             line = line.split(' %', 1)[0].strip()
-            if v >= 5: print "/{}/".format(line)
+            if v >= 5: print("/{}/".format(line))
             clause = tuple(line.split(' '))
             if len(clause) > 1: #remove lines that are comments and started with whitespace
                 clf.append(clause)
@@ -210,7 +210,7 @@ def file_to_clfs(filepath, v=0):
 #################################
 def report_error(message, v=0):
     if v >= 1: 
-        print "ERROR: {}".format(message)
+        print("ERROR: {}".format(message))
     raise RuntimeError(message)  
 
 #################################
@@ -272,32 +272,32 @@ class Box:
 def pr_box(box, indent=0):
     '''Print a box object'''
     ind = indent * ' '
-    print ind, 20 * '_'
-    print ind, box.name
+    print(ind, 20 * '_')
+    print(ind, box.name)
     #discourse referents
-    print ind, '| ', ' '.join(box.refs)
+    print(ind, '| ', ' '.join(box.refs))
     if box.box_refs:
-        print ind, '[[ ', ' '.join(box.box_refs)
-    print ind, 20 * '-'
+        print(ind, '[[ ', ' '.join(box.box_refs))
+    print(ind, 20 * '-')
     if box.conds:
         for c in box.conds:
-            print ind, '| ', ' '.join(c)
+            print(ind, '| ', ' '.join(c))
     if box.rels:
         for r in box.rels: 
-            print ind, '[ ', ' '.join(r), ' ]'  
+            print(ind, '[ ', ' '.join(r), ' ]'  )
     if box.cond_refs:
-        print ind, '{ ', ' '.join(box.cond_refs), ' }'  
+        print(ind, '{ ', ' '.join(box.cond_refs), ' }'  )
     if box.rel_boxes:
-        print ind, '[{ ', ' '.join(box.rel_boxes), ' ]]'
+        print(ind, '[{ ', ' '.join(box.rel_boxes), ' ]]')
     if box.subs:
-        print ind, '< ', ' '.join(box.subs), ' >'
+        print(ind, '< ', ' '.join(box.subs), ' >')
 
 #################################
 def pr_2rel(rel, pr=False, sep='>'):
     '''Print binary relation'''
     message = '{ ' + ', '.join([a + sep + b for (a, b) in rel]) + ' }'
     if pr:
-        print message
+        print(message)
     else:
         return message
 
@@ -307,7 +307,7 @@ def pr_clf(clf, pr=False, inline=True, indent=0):
     sep = '; ' if inline else '\n' + indent * ' ' 
     message = sep.join([pr_clause(clause) for clause in clf])
     if pr:
-        print indent * ' ' + message
+        print(indent * ' ' + message)
     else:
         return indent * ' ' + message
 
@@ -316,7 +316,7 @@ def pr_set(set, pr=False):
     '''Print set with simple elements'''
     message = '{ ' + ', '.join(set) + ' }'
     if pr:
-        print message
+        print(message)
     else:
         return message
 
@@ -325,7 +325,7 @@ def pr_clause(clause, pr=False):
     '''Make clause prettier (and print it if needed)'''
     message = ' '.join(clause)
     if pr:
-        print message
+        print(message)
     else:
         return message
 
@@ -336,20 +336,20 @@ def clf_to_box_dict(clf, op_types, arg_typing, v=0):
     for (i, cl) in enumerate(clf):
         op_type = op_types[i]
         if v>=4: 
-            print 30 * '#'
+            print(30 * '#')
             for b in box_dict:
                 pr_box(box_dict[b], indent=5)   
         # Reference clause: b REF x
         if op_type in ['REF']:
             (b, op, x) = cl
-            if v >=4: print "Adding {} to {} as {}".format(cl, b, op_type)
+            if v >=4: print("Adding {} to {} as {}".format(cl, b, op_type))
             assert (arg_typing[b], arg_typing[x]) == ('b', 'x') 
             box_dict.setdefault(b, Box(b)).refs.add(x)
             continue
         # clause for a condition with a single DRS
         if op_type in ['NOT', 'POS', 'NEC']:
             (b0, op, b1) = cl
-            if v >=4: print "Adding {} to {} as {}".format(cl, b0, op_type)
+            if v >=4: print("Adding {} to {} as {}".format(cl, b0, op_type))
             assert (arg_typing[b0], arg_typing[b1]) == ('b', 'b') 
             box_dict.setdefault(b0, Box(b0)).conds.add((op, b1))
             box_dict[b0].subs.add(b1)
@@ -358,7 +358,7 @@ def clf_to_box_dict(clf, op_types, arg_typing, v=0):
         # clause for an SDRS-formula: k DRS b
         if op_type in ['DRS']:
             (k, op, b) = cl
-            if v >=4: print "Adding {} to {} as {}".format(cl, k, op_type)
+            if v >=4: print("Adding {} to {} as {}".format(cl, k, op_type))
             assert (arg_typing[k], arg_typing[b]) == ('b', 'b') 
             box_dict.setdefault(k, Box(k)).box_refs.add(b)
             box_dict[k].subs.add(b)
@@ -367,7 +367,7 @@ def clf_to_box_dict(clf, op_types, arg_typing, v=0):
         # clause for an implication (b0 IMP b1 b2) or duplex (b0 DUP b1 b2) condition  
         if op_type in ['IMP', 'DUP']:
             (b0, op, b1, b2) = cl
-            if v >=4: print "Adding {} to {} as {}".format(cl, b0, op_type)
+            if v >=4: print("Adding {} to {} as {}".format(cl, b0, op_type))
             assert (arg_typing[b0], arg_typing[b1], arg_typing[b2]) == ('b', 'b', 'b') 
             box_dict.setdefault(b0, Box(b0)).conds.add((op, b1, b2))
             box_dict[b0].subs.update([b1, b2])
@@ -378,7 +378,7 @@ def clf_to_box_dict(clf, op_types, arg_typing, v=0):
         # clause for a disjunction condition: b0 DIS b1 b2  
         if op_type in ['DIS']:
             (b0, op, b1, b2) = cl
-            if v >=4: print "Adding {} to {} as {}".format(cl, b0, op_type)
+            if v >=4: print("Adding {} to {} as {}".format(cl, b0, op_type))
             assert (arg_typing[b0], arg_typing[b1], arg_typing[b2]) == ('b', 'b', 'b') 
             box_dict.setdefault(b0, Box(b0)).conds.add((op, b1, b2))
             box_dict[b0].subs.update([b1, b2])
@@ -388,7 +388,7 @@ def clf_to_box_dict(clf, op_types, arg_typing, v=0):
         # clause for a propositional condition
         if op_type in ['PRP']:
             (b0, op, x, b1) = cl
-            if v >=4: print "Adding {} to {} as {}".format(cl, b0, op_type)
+            if v >=4: print("Adding {} to {} as {}".format(cl, b0, op_type))
             assert (arg_typing[b0], arg_typing[x], arg_typing[b1]) == ('b', 'x', 'b') 
             box_dict.setdefault(b0, Box(b0)).conds.add((op, x, b1))
             box_dict[b0].subs.add(b1)
@@ -400,7 +400,7 @@ def clf_to_box_dict(clf, op_types, arg_typing, v=0):
         if op_type in ['LEX']:
             (b, op, pos, t) = cl
             assert (arg_typing[b], arg_typing[pos]) == ('b', 'c') and unify_types(arg_typing[t], 't')
-            if v >=4: print "Adding {} to {} as {}".format(cl, b, op_type)
+            if v >=4: print("Adding {} to {} as {}".format(cl, b, op_type))
             box_dict.setdefault(b, Box(b)).conds.add((op, pos, t))
             #print "!!! {} is of type {}".format(t, arg_typing[t]) 
             if arg_typing[t] == 'x': 
@@ -410,7 +410,7 @@ def clf_to_box_dict(clf, op_types, arg_typing, v=0):
         # clause for a discourse relation
         if op_type in ['REL']:
             (b0, op, b1, b2) = cl
-            if v >=4: print "Adding {} to {} as {}".format(cl, b0, op_type)
+            if v >=4: print("Adding {} to {} as {}".format(cl, b0, op_type))
             assert (arg_typing[b0], arg_typing[b1], arg_typing[b2]) == ('b', 'b', 'b')
             box_dict.setdefault(b0, Box(b0)).rels.add((op, b1, b2))
             box_dict.setdefault(b0).rel_boxes.update([b1, b2])
@@ -419,7 +419,7 @@ def clf_to_box_dict(clf, op_types, arg_typing, v=0):
         if op_type in ['ROL']:
             (b, op, t1, t2) = cl
             assert arg_typing[b] == 'b' and unify_types(arg_typing[t1], 't') and unify_types(arg_typing[t2], 't') 
-            if v >=4: print "Adding {} to {} as {}".format(cl, b, op_type)
+            if v >=4: print("Adding {} to {} as {}".format(cl, b, op_type))
             #pr_box(Box(b), indent=10)
             #print "conditions = {}".format(box_dict.setdefault(b, Box(b)).conds)
             box_dict.setdefault(b, Box(b)).conds.add((op, t1, t2))
@@ -447,7 +447,7 @@ def box_dict_to_subordinate_rel(box_dict, v=0):
         for b1 in box_dict[b0].subs:
             # b0 subordinates b1
             subs.add((b0, b1))
-    if v>=4: print "direct subs: {}".format(pr_2rel(sorted(subs)))
+    if v>=4: print("direct subs: {}".format(pr_2rel(sorted(subs))))
     old_subs = subs.copy()
     # if b2's condition uses referent introduced by b1,
     # then make b1 subordinate b2
@@ -461,7 +461,7 @@ def box_dict_to_subordinate_rel(box_dict, v=0):
                     if (b1 != b2) and (ref in box_dict[b1].refs):
                         # b1 introduces referent that b2 uses
                         subs.add((b1, b2))
-    if v>=4: print "+ accessibility subs: {}".format(pr_2rel(sorted(subs - old_subs)))
+    if v>=4: print("+ accessibility subs: {}".format(pr_2rel(sorted(subs - old_subs))))
     # get closure of subs by combining simple transitive rule
     # and subordination connectivity, which encourages connectivity of teh relation  
     # connectivity: if b0 directly subordinates b1, 
@@ -499,7 +499,7 @@ def transitive_closure(relation, v=0):
         # exit when no increase is detected
         if temp_rel == tran_closure:
             break 
-    if v>=4: print "+ transitivity closure: {}".format(pr_2rel(sorted(tran_closure - relation)))
+    if v>=4: print("+ transitivity closure: {}".format(pr_2rel(sorted(tran_closure - relation))))
     return tran_closure
 
 #################################
@@ -512,7 +512,7 @@ def connectivity_closure(box_dict, subs, v=0):
             # add b>b0 if b>b1 directly, works well in practice 
             for b in [ b2 for (b2, b3) in subs if b3 == b1 and b2 != b0 and (b0, b2) not in subs ]: 
                 cl_subs.add((b, b0))   
-    if v>=4: print "+ connectivity closure: {}".format(pr_2rel(sorted(cl_subs - subs)))
+    if v>=4: print("+ connectivity closure: {}".format(pr_2rel(sorted(cl_subs - subs))))
     return cl_subs
 
 #################################
@@ -527,7 +527,7 @@ def detect_main_box(box_dict, sub_rel, v=0):
         # there is no b1 that contains b0 in relations or conditions
         if not next(( b1 for b1 in box_dict if b0 in box_dict[b1].subs or b0 in box_dict[b1].rel_boxes ), False):
             independent_boxes.add(b0)
-    if v>=3: print "independent_boxes = {}".format(pr_set(independent_boxes))
+    if v>=3: print("independent_boxes = {}".format(pr_set(independent_boxes)))
     # get the independent boxe that is subordinate to the rest of the independent boxes 
     main_box = set()  
     for b in independent_boxes:
@@ -548,7 +548,7 @@ def unbound_referents(box_dict, sub_rel, v=0):
     unbound = set()           
     for b in box_dict:
         outsider_refs = box_dict[b].cond_refs - box_dict[b].refs
-        #print "outsider refs for {} are {}".format(b, pr_set(outsider_refs))
+        #print("outsider refs for {} are {}".format(b, pr_set(outsider_refs)))
         for x in outsider_refs:
             # find a box subordinating the current one and introducing x as referent     
             if not next(( b1 for (b1, b2) in sub_rel 
@@ -587,7 +587,7 @@ if __name__ == '__main__':
     args = parse_arguments()
     (clfs, raws) = file_to_clfs(args.src, v=args.v) 
     total = len(clfs)
-    if args.v >= 1: print "{} clausal forms (with {} raw) retrieved".format(total, len(raws))
+    if args.v >= 1: print("{} clausal forms (with {} raw) retrieved".format(total, len(raws)))
     # get info about signature as dictionary
     signature = get_signature(args.sig_file, v=args.v)    
     # check each clausal form
@@ -595,25 +595,25 @@ if __name__ == '__main__':
     op_type_counter = Counter()
     for (i, clf) in enumerate(clfs):
         counter_prog(i)
-        if args.v >= 2 and raws: print ' "{}"'.format(raws[i]) 
+        if args.v >= 2 and raws: print(' "{}"'.format(raws[i]))
         try:
             (mbox, box_dict, subs, op_types) = check_clf(clf, signature, v=args.v)
             op_type_counter.update(op_types)
         except RuntimeError as e:
             error_counter.update([e[0]])
             if args.v >= 1: 
-                print "In the CLF:\n{}".format(pr_clf(clf))                
-    print "Done"
+                print("In the CLF:\n{}".format(pr_clf(clf)))
+    print("Done")
     error_total = sum(error_counter.values())
-    print "#wrong = {} ({:.2f}%)".format(error_total, error_total*100/float(total))  
+    print("#wrong = {} ({:.2f}%)".format(error_total, error_total*100/float(total)))
     if args.v >= 1:
         # print frequency of errors
-        if error_counter: print "Error frequency"
+        if error_counter: print("Error frequency")
         for (err, c) in error_counter.most_common():
-            print c, err 
+            print(c, err)
         # print frequency of operator types
-        if op_type_counter: print "Operator type frequency"
+        if op_type_counter: print("Operator type frequency")
         for (op_type, c) in op_type_counter.most_common():
-            print c, op_type 
+            print(c, op_type)
             
 

--- a/evaluation/counter.py
+++ b/evaluation/counter.py
@@ -55,8 +55,15 @@ except ImportError:
         import pickle
 
 from numpy import median
-reload(sys)
-sys.setdefaultencoding('utf-8')  # necessary to avoid unicode errors
+
+try:
+        # only needed for Python 2
+        reload(sys)
+        sys.setdefaultencoding('utf-8')  # necessary to avoid unicode errors
+except:
+        pass
+
+
 import psutil  # for memory usage
 
 # Imports for the hillclimbing algorithm

--- a/evaluation/counter.py
+++ b/evaluation/counter.py
@@ -137,15 +137,15 @@ def build_arg_parser():
 		raise ValueError('Number of restarts must be larger than 0')
 
 	if args.ms and args.parallel > 1:
-		print 'WARNING: using -ms and -p > 1 messes up printing to screen - not recommended'
+		print('WARNING: using -ms and -p > 1 messes up printing to screen - not recommended')
 		time.sleep(5)  # so people can still read the warning
 	
 	if args.ill != 'error':
-		print 'WARNING: by using -ill {0}, ill-formed DRSs are replaced by a {0} DRS'.format(args.ill)
+		print('WARNING: by using -ill {0}, ill-formed DRSs are replaced by a {0} DRS'.format(args.ill))
 		time.sleep(3)
 		
 	if args.runs > 1 and args.prin:
-		print 'WARNING: we do not print specific information (-prin) for runs > 1, only final averages'
+		print('WARNING: we do not print specific information (-prin) for runs > 1, only final averages')
 		time.sleep(5)
 
 	if args.partial:
@@ -192,11 +192,11 @@ def get_clauses(file_name, signature, ill_type):
 						if ill_type == 'error':
 							raise ValueError(e)
 						elif ill_type == 'dummy':
-							print 'WARNING: DRS {0} is ill-formed and replaced by a dummy DRS'.format(len(clause_list) +1)
+							print('WARNING: DRS {0} is ill-formed and replaced by a dummy DRS'.format(len(clause_list) +1))
 							clause_list.append(dummy_drs())
 							original_clauses.append([" ".join(x) for x in dummy_drs()])
 						elif ill_type == 'spar':
-							print 'WARNING: DRS {0} is ill-formed and replaced by the SPAR DRS'.format(len(clause_list) +1)
+							print('WARNING: DRS {0} is ill-formed and replaced by the SPAR DRS'.format(len(clause_list) +1))
 							clause_list.append(spar_drs())
 							original_clauses.append([" ".join(x) for x in spar_drs()])		
 				cur_clauses = []
@@ -270,7 +270,7 @@ def get_num_concepts(clause_list, pos_tag):
 				if cur_pos_tag == pos_tag:
 					num_concepts += 1
 			except:
-				print 'Strange concept clause', " ".join(clause)		
+				print('Strange concept clause', " ".join(clause))
 	return num_concepts
 
 
@@ -298,7 +298,7 @@ def get_detailed_results(match):
 				if pos_tag in event_tags:
 					match_division[7] += 1	
 			except:
-				print 'Strange concept clause:', " ".join(spl_line)
+				print('Strange concept clause:', " ".join(spl_line))
 	return match_division				
 
 
@@ -390,7 +390,7 @@ def get_matching_clauses(arg_list):
 	gold_drs.get_specific_clauses(gold_t, en_sense_dict, args)
 	
 	if single and (args.max_clauses > 0 and ((prod_drs.total_clauses > args.max_clauses) or (gold_drs.total_clauses > args.max_clauses))):
-		print 'Skip calculation of DRS, more clauses than max of {0}'.format(args.max_clauses)
+		print('Skip calculation of DRS, more clauses than max of {0}'.format(args.max_clauses))
 		return 'skip'
 
 	if args.stats: #only do stats
@@ -413,8 +413,8 @@ def get_matching_clauses(arg_list):
 				[uniq_rewrite.append(item) for item in rewrite_list if item not in uniq_rewrite] #only unique transformations, but keep order
 
 				# Print match and non-match to screen
-				for print_line in print_match: print print_line
-				for print_line in print_no_match: print print_line
+				for print_line in print_match: print(print_line)
+				for print_line in print_no_match: print(print_line)
 		else:
 			match_division = []
 			idv_dict = {}		
@@ -455,35 +455,35 @@ def print_results(res_list, no_print, start_time, single, args):
 	elif no_print:  # averaging over multiple runs, don't print results
 		return [precision, recall, best_f_score]
 	else:
-		print '\n## Clause information ##\n'
-		print 'Clauses prod : {0}'.format(total_test_num)
-		print 'Clauses gold : {0}\n'.format(total_gold_num)
+		print('\n## Clause information ##\n')
+		print('Clauses prod : {0}'.format(total_test_num))
+		print('Clauses gold : {0}\n'.format(total_gold_num))
 		if args.max_clauses > 0:
-			print 'Max number of clauses per DRS:  {0}\n'.format(args.max_clauses)
-		print '## Main Results ##\n'
+			print('Max number of clauses per DRS:  {0}\n'.format(args.max_clauses))
+		print('## Main Results ##\n')
 		if not single:
-			print 'All shown number are micro-averages calculated over {0} DRS-pairs\n'.format(len(res_list))
-		print 'Matching clauses: {0}\n'.format(total_match_num)
-		print "Precision: {0}".format(round(precision, args.significant))
-		print "Recall   : {0}".format(round(recall, args.significant))
-		print "F-score  : {0}".format(round(best_f_score, args.significant))
+			print('All shown number are micro-averages calculated over {0} DRS-pairs\n'.format(len(res_list)))
+		print('Matching clauses: {0}\n'.format(total_match_num))
+		print("Precision: {0}".format(round(precision, args.significant)))
+		print("Recall   : {0}".format(round(recall, args.significant)))
+		print("F-score  : {0}".format(round(best_f_score, args.significant)))
 
 		# Print specific output here
 		if args.prin:
-			print '\n## Detailed precision, recall, F-score ##\n'
+			print('\n## Detailed precision, recall, F-score ##\n')
 			for idx in range(0,len(name_list)):
-				print 'Prec, rec, F1 {0}: {1}, {2}, {3}'.format(name_list[idx], res_dict[name_list[idx]][0], res_dict[name_list[idx]][1], res_dict[name_list[idx]][2])
+				print('Prec, rec, F1 {0}: {1}, {2}, {3}'.format(name_list[idx], res_dict[name_list[idx]][0], res_dict[name_list[idx]][1], res_dict[name_list[idx]][2]))
 			if args.smart == 'conc':
 				smart_conc = compute_f(sum([y[0] for y in [x[3] for x in res_list]]), total_test_num, total_gold_num, args.significant, True)
-				print 'Smart F-score concepts: {0}\n'.format(smart_conc)
+				print('Smart F-score concepts: {0}\n'.format(smart_conc))
 
 			# For a single DRS we can print some more information
 			if single:
-				print '\n## Restarts and processing time ##\n'
-				print 'Num restarts specified       : {0}'.format(args.restarts)
-				print 'Found best mapping at restart: {0}'.format(int(found_idx))
+				print('\n## Restarts and processing time ##\n')
+				print('Num restarts specified       : {0}'.format(args.restarts))
+				print('Found best mapping at restart: {0}'.format(int(found_idx)))
 
-	print 'Total processing time: {0} sec'.format(runtime)
+	print('Total processing time: {0} sec'.format(runtime))
 	return [precision, recall, best_f_score]
 
 
@@ -491,23 +491,23 @@ def check_input(clauses_prod_list, original_prod, original_gold, clauses_gold_li
 	'''Check if the input is valid -- or fill baseline if that is asked'''
 	if baseline:  # if we try a baseline DRS, we have to fill a list of this baseline
 		if len(clauses_prod_list) == 1:
-			print 'Testing baseline DRS vs {0} DRSs...\n'.format(len(clauses_gold_list))
+			print('Testing baseline DRS vs {0} DRSs...\n'.format(len(clauses_gold_list)))
 			clauses_prod_list = fill_baseline_list(clauses_prod_list[0], clauses_gold_list)
 			original_prod = fill_baseline_list(original_prod[0], original_gold)
 		else:
 			raise ValueError("Using --baseline, but there is more than 1 DRS in prod file")
 	elif len(clauses_prod_list) != len(clauses_gold_list):
-		print "Number of DRSs not equal, {0} vs {1}, exiting...".format(len(clauses_prod_list), len(clauses_gold_list))
+		print("Number of DRSs not equal, {0} vs {1}, exiting...".format(len(clauses_prod_list), len(clauses_gold_list)))
 		sys.exit(0)
 	elif len(clauses_prod_list) == 0 and len(clauses_gold_list) == 0:
-		print "Both DRSs empty, exiting..."
+		print("Both DRSs empty, exiting...")
 		sys.exit(0)
 	elif not single:
-		print 'Comparing {0} DRSs...\n'.format(len(clauses_gold_list))
+		print('Comparing {0} DRSs...\n'.format(len(clauses_gold_list)))
 
 	# Print number of DRSs we skip due to the -max_clauses parameter
 	if max_clauses > 0 and not single:
-		print 'Skipping {0} DRSs due to their length exceeding {1} (--max_clauses)\n'.format(len([x for x, y in zip(clauses_gold_list, clauses_prod_list) if len(x) > max_clauses or len(y) > max_clauses]), max_clauses)
+		print('Skipping {0} DRSs due to their length exceeding {1} (--max_clauses)\n'.format(len([x for x, y in zip(clauses_gold_list, clauses_prod_list) if len(x) > max_clauses or len(y) > max_clauses]), max_clauses))
 	return original_prod, clauses_prod_list
 
 
@@ -632,7 +632,7 @@ class DRS:
 
 		# Operators that have two box variables
 		for idx, cur_clause in enumerate(clause_list):
-			#print cur_clause
+			#print(cur_clause)
 			# Clause has three items and belongs in op_two_vars (b0 REF x1 ,  b0 NOT b1)
 			if len(cur_clause) == 3:
 				val0 = self.rename_var(cur_clause[0], 'b', args)
@@ -676,9 +676,9 @@ def save_detailed_stats(all_dicts, args):
 	
 	# Now print a nicely aligned tab-list for the three types of clauses so it is easier to keep them straight
 	for idx, item in enumerate(print_list):
-		print '\n{0} {1}:\n'.format(print_line, print_headers[idx].lower())
+		print('\n{0} {1}:\n'.format(print_line, print_headers[idx].lower()))
 		to_print = create_tab_list([[print_headers[idx], 'F-score','Gold inst']] + print_list[idx], [], '\t')
-		for t in to_print: print t
+		for t in to_print: print(t)
 									
 
 def save_stats(all_clauses, all_vars, stat_file):
@@ -690,8 +690,8 @@ def save_stats(all_clauses, all_vars, stat_file):
 			best_idx = idx
 
 	drs_max_clauses, mean_clauses, mean_variables = best_idx + 1, float(sum(all_clauses)) / float(len(all_clauses)), float(sum(all_vars)) / float(len(all_vars))
-	print '\nStatistics:\n\nDRS {0} has max clauses\nLen DRSs: {1}\nMean clauses: {2}\nMedian clauses: {3}\nMax clauses: {4}\n'.format(drs_max_clauses, len(all_clauses), mean_clauses, median(all_clauses), max(all_clauses))
-	print 'Mean variables: {0}\nMedian variables: {1}\nMax variables: {2}\n'.format(mean_variables, median(all_vars), max(all_vars))
+	print('\nStatistics:\n\nDRS {0} has max clauses\nLen DRSs: {1}\nMean clauses: {2}\nMedian clauses: {3}\nMax clauses: {4}\n'.format(drs_max_clauses, len(all_clauses), mean_clauses, median(all_clauses), max(all_clauses)))
+	print('Mean variables: {0}\nMedian variables: {1}\nMax variables: {2}\n'.format(mean_variables, median(all_vars), max(all_vars)))
 
 	dump_lists = [all_clauses, all_vars]
 	cPickle.dump(dump_lists, open(stat_file, 'w'))
@@ -745,10 +745,10 @@ def main(args):
 
 	# If multiple runs, print averages
 	if res and args.runs > 1 and not args.stats:
-		print 'Average scores over {0} runs:\n'.format(args.runs)
-		print 'Precision: {0}'.format(round(float(sum([x[0] for x in res])) / float(args.runs), args.significant))
-		print 'Recall   : {0}'.format(round(float(sum([x[1] for x in res])) / float(args.runs), args.significant))
-		print 'F-score  : {0}'.format(round(float(sum([x[2] for x in res])) / float(args.runs), args.significant))
+		print('Average scores over {0} runs:\n'.format(args.runs))
+		print('Precision: {0}'.format(round(float(sum([x[0] for x in res])) / float(args.runs), args.significant)))
+		print('Recall   : {0}'.format(round(float(sum([x[1] for x in res])) / float(args.runs), args.significant)))
+		print('F-score  : {0}'.format(round(float(sum([x[2] for x in res])) / float(args.runs), args.significant)))
 	
 	# print scores in scores.txt file for codalab usage
 	if len(res) == 1 and args.runs == 1 and args.codalab:

--- a/evaluation/counter.py
+++ b/evaluation/counter.py
@@ -48,7 +48,12 @@ import sys
 import multiprocessing
 from multiprocessing import Pool
 import json #reading in dict
-import cPickle
+
+try:
+        import cPickle as pickle
+except ImportError:
+        import pickle
+
 from numpy import median
 reload(sys)
 sys.setdefaultencoding('utf-8')  # necessary to avoid unicode errors
@@ -694,7 +699,7 @@ def save_stats(all_clauses, all_vars, stat_file):
 	print('Mean variables: {0}\nMedian variables: {1}\nMax variables: {2}\n'.format(mean_variables, median(all_vars), max(all_vars)))
 
 	dump_lists = [all_clauses, all_vars]
-	cPickle.dump(dump_lists, open(stat_file, 'w'))
+	pickle.dump(dump_lists, open(stat_file, 'w'))
 
 
 def main(args):

--- a/evaluation/hill_climbing.py
+++ b/evaluation/hill_climbing.py
@@ -80,7 +80,7 @@ def get_best_match(prod_drs, gold_drs, args, single):
 				(gain, new_mapping, match_clause_dict) = get_best_gain(cur_mapping, candidate_mappings, weight_dict, num_vars, match_clause_dict)
 
 				if match_num + gain > prod_drs.total_clauses:
-					print new_mapping, match_num + gain, prod_drs.total_clauses
+					print(new_mapping, match_num + gain, prod_drs.total_clauses)
 					raise ValueError(
 						"More matches than there are produced clauses. If this ever occurs something is seriously wrong with the algorithm")
 
@@ -110,7 +110,7 @@ def get_best_match(prod_drs, gold_drs, args, single):
 		# stop instead of doing all other restarts - but always do smart mappings
 		if match_num == prod_drs.total_clauses and i > len(smart_fscores) - 1:
 			if args.prin and single:
-				print 'Best match already found, stop restarts at restart {0}'.format(i)
+				print('Best match already found, stop restarts at restart {0}'.format(i))
 			if i < len(smart_fscores):
 				smart_fscores[i] = match_num
 			break

--- a/evaluation/hill_climbing.py
+++ b/evaluation/hill_climbing.py
@@ -131,7 +131,7 @@ def get_best_match(prod_drs, gold_drs, args, single):
 def add_random_mapping(result, matched_dict, candidate_mapping):
 	'''If mapping is still -1 after adding a smart mapping, randomly fill in the blanks'''
 	# First shuffle the way we loop over result, so that we increase the randomness of the mappings
-	indices = range(len(result))
+	indices = list(range(len(result)))
 	random.shuffle(indices)
 	for idx in indices:
 		if result[idx] == -1:  # no mapping yet

--- a/evaluation/utils_counter.py
+++ b/evaluation/utils_counter.py
@@ -108,8 +108,16 @@ def create_tab_list(print_rows, print_item, joiner):
 		return_rows = []
 	if print_rows:
 		for idx in range(len(print_rows[0])):  # for nice printing, calculate max column length
-			col_widths.append(max([len(x[idx].decode('utf-8')) for x in print_rows]) + 1)
+			try:
+				col_widths.append(max([len(x[idx].decode('utf-8')) for x in print_rows]) + 1)
+			except AttributeError:
+				# in Python 3 a string is utf8 and has no decode
+				col_widths.append(max([len(x[idx]) for x in print_rows]) + 1)
 
 		for idx, row in enumerate(print_rows):  # print rows here, adjusted for column width
-			return_rows.append(joiner.join(word.decode('utf-8').ljust(col_widths[col_idx]) for col_idx, word in enumerate(row)))
+			try:
+				return_rows.append(joiner.join(word.decode('utf-8').ljust(col_widths[col_idx]) for col_idx, word in enumerate(row)))
+			except AttributeError:
+				# in Python 3 a string is utf8 and has no decode
+				return_rows.append(joiner.join(word.ljust(col_widths[col_idx]) for col_idx, word in enumerate(row)))
 	return return_rows

--- a/parsing/amr2drs.py
+++ b/parsing/amr2drs.py
@@ -291,7 +291,7 @@ def get_argument(arg, arg_dict):
 	try:
 		final_arg = arg[1].upper() + arg[2:]
 	except:
-		print "WARNING: strange AMR argument", arg, "return Agent as default"
+		print("WARNING: strange AMR argument", arg, "return Agent as default")
 		final_arg = "Agent"
 
 	return [final_arg, False]
@@ -438,6 +438,6 @@ if __name__ == "__main__":
 			for d in drs:
 				out_f.write(d.strip() + '\n')
 			out_f.write('\n')
-	print "Changed {0} AMRs to DRS".format(len(amrs))
+	print("Changed {0} AMRs to DRS".format(len(amrs)))
 
 

--- a/parsing/spar.py
+++ b/parsing/spar.py
@@ -21,4 +21,4 @@ k0 smile "v.01" e1
 """
 
     for line in open(sys.argv[1], 'r'):
-        print baseline.strip() + '\n'
+        print(baseline.strip() + '\n')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy==1.15.4
+psutil==5.4.8
+PyYAML==3.13

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# run all example calls from readme
+
+(
+    cd evaluation
+    python clf_referee.py ../data/boxer_parse_dev.txt
+    python counter.py -f1 ../data/boxer_parse_dev.txt -f2 ../data/dev.txt
+    python counter.py -f1 ../data/boxer_parse_dev.txt -f2 ../data/dev.txt -r 20 -s no
+    python counter.py -f1 ../data/boxer_parse_dev.txt -f2 ../data/dev.txt -p 4 -s no
+    python counter.py -f1 ../data/boxer_parse_dev.txt -f2 ../data/dev.txt -prin -s conc
+    python counter.py -f1 ../data/boxer_parse_dev.txt -f2 ../data/dev.txt -prin -ds 10
+    python counter.py -f1 ..//data/baseline_drs.txt -f2 ../data/baseline_drs.txt -prin
+    python counter.py -f1 ../data/boxer_parse_dev.txt -f2 ../data/dev.txt -p 1 -ms
+    python counter.py -f1 ../data/baseline_drs.txt -f2 ../data/dev.txt -prin --baseline
+    python counter.py -f1 ../data/boxer_parse_dev.txt -f2 ../data/dev.txt -r 50 -dse
+)
+(
+    cd parsing
+    python spar.py ../data/amr_sample.txt
+    python amr2drs.py -i ../data/amr_sample.txt -d OUTPUT_FILE
+)


### PR DESCRIPTION
By using *six*¹ some of the try/excepts could be replaced by nicer solutions.
But for so few incompatibilities this should be ok.

I tested my changes with Python 3.7.1 but everything should work with Python 3.5+.

Your code could profit a lot by following common Python style guides like pep8.
Maybe you could use *black*² to reformat your code to comply with them.

¹ https://pypi.org/project/six/
² https://pypi.org/project/black/